### PR TITLE
Update compatibility/wildcrafttrees/bark.json

### DIFF
--- a/assets/ancienttools/patches/compatibility/wildcrafttrees/bark.json
+++ b/assets/ancienttools/patches/compatibility/wildcrafttrees/bark.json
@@ -104,7 +104,7 @@
 		"op": "add",
 		"path": "/grindingPropsByType/*-spruce",
 		"value": {
-			grindedStack: { type: "item", code: "game:flour-spruce" }
+			groundStack: { type: "item", code: "game:flour-spruce" }
 		},
 		"file": "ancienttools:itemtypes/resources/bark",
 		"dependsOn": [{ "modid": "wildcrafttrees" }],


### PR DESCRIPTION
line 107: grindedStack (obsolete) to groundStack.