### PR TITLE
Fix wedgesmold.json to be patchable by Rivers mod.

### DIFF
--- a/assets/ancienttools/recipes/clayforming/wedgesmold.json
+++ b/assets/ancienttools/recipes/clayforming/wedgesmold.json
@@ -1,5 +1,4 @@
-﻿[
-	{
+﻿	{
 	ingredient: { type: "item", code: "game:clay-*", name: "type", allowedVariants: ["blue", "fire"] },
 	pattern: [[
 		"##############",
@@ -36,4 +35,3 @@
 	name: "Wedges Mold",
 	output: { type: "block", code: "toolmoldancienttools-raw-wedge"  }
 }
-]


### PR DESCRIPTION
Issue: "19.5.2024 13:53:46 [Server Error] Rivers: failed to patch clayforming recipe wedgesmold.json."

Issue solution: https://discord.com/channels/302152934249070593/1181546520894517268/1241737596057423965

Removed [] to make it work.