### PR TITLE
Fix malformed modinfo.json

### DIFF
--- a/modinfo.json
+++ b/modinfo.json
@@ -8,6 +8,6 @@
   "description": "A collection of useful tools from ancient times.",
   "version": "1.5.24",
   "dependencies": {
-    "game": "1.20.0",
+    "game": "1.20.0"
   }
 }


### PR DESCRIPTION
Json does not allow trailing commas, so this is causing issues when trying to parse the modinfo.json automatically