### PR TITLE
Update CarryOn pitchpot, salvepot patches to Ancient Tool v1.6.0-pre.4

### DIFF
--- a/assets/ancienttools/patches/compatibility/carryon/pitchpot.json
+++ b/assets/ancienttools/patches/compatibility/carryon/pitchpot.json
@@ -1,7 +1,7 @@
 ﻿[
 	{
 		"op": "add",
-		"path": "/behaviorsByType/@pitchpot-(unmixed|unmixedresiduecovered)/-",
+		"path": "/behaviorsByType/@pitchpot-(blue|fire|black|brown|cream|gray|orange|red|tan)-(unmixed|unmixedresiduecovered)/-",
 		"value": {
 			name: "Carryable", properties: {
 
@@ -9,7 +9,7 @@
 			rotation: [ 0, 0, 0 ],
 			origin: [ 0.5, 0.5, 0.5 ],
 			scale: [ 0.5, 0.5, 0.5 ],
-    
+
 			interactDelay: 0.4,
 				slots: {
 				"Hands": {
@@ -17,7 +17,7 @@
 					walkSpeedModifier: -0.15,
 				}
 				}
-			} 
+			}
 		},
 		"file": "ancienttools:blocktypes/pitchpot",
 		"dependsOn": [{ "modid": "carryon" }],
@@ -25,7 +25,7 @@
 	},
 	{
 		"op": "add",
-		"path": "/behaviorsByType/@pitchpot-(empty|finishedpitch)/-",
+		"path": "/behaviorsByType/@pitchpot-(blue|fire|black|brown|cream|gray|orange|red|tan)-(empty|finishedpitch)/-",
 		"value": {
 			name: "Carryable", properties: {
 
@@ -33,7 +33,7 @@
 			rotation: [ 0, 0, 0 ],
 			origin: [ 0.5, 0.5, 0.5 ],
 			scale: [ 0.5, 0.5, 0.5 ],
-    
+
 			interactDelay: 0.4,
 				slots: {
 				"Hands": {
@@ -41,7 +41,7 @@
 					walkSpeedModifier: -0.15,
 				},
 				}
-			} 
+			}
 		},
 		"file": "ancienttools:blocktypes/pitchpot",
 		"dependsOn": [{ "modid": "carryon" }],

--- a/assets/ancienttools/patches/compatibility/carryon/salvepot.json
+++ b/assets/ancienttools/patches/compatibility/carryon/salvepot.json
@@ -1,7 +1,7 @@
 ﻿[
 	{
 		"op": "add",
-		"path": "/behaviorsByType/@salvepot-(birch|birchresiduecovered|pine|pineresiduecovered|maple|mapleresiduecovered|oak|oakresiduecovered|acacia|acaciaresiduecovered|hardwax|hardwaxresiduecovered|softwax|barkoil)/-",
+		"path": "/behaviorsByType/@salvepot-(blue|fire|black|brown|cream|gray|orange|red|tan)-(birch|birchresiduecovered|pine|pineresiduecovered|maple|mapleresiduecovered|oak|oakresiduecovered|acacia|acaciaresiduecovered|hardwax|hardwaxresiduecovered|softwax|barkoil)/-",
 		"value": {
 			name: "Carryable", properties: {
 
@@ -25,7 +25,7 @@
 	},
 	{
 		"op": "add",
-		"path": "/behaviorsByType/@salvepot-(empty|residuecovered|finishedsalve)/-",
+		"path": "/behaviorsByType/@salvepot-(blue|fire|black|brown|cream|gray|orange|red|tan)-(empty|residuecovered|finishedsalve)/-",
 		"value": {
 			name: "Carryable", properties: {
 


### PR DESCRIPTION
These commits change the patch "path" properties in the erroneous CarryOn patches to match the changes made in to the pitch and salve pots' defintions in release 1.6.0-pre.4.